### PR TITLE
remove query message to reduce noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ version: 2
 updates:
   - package-ecosystem: "dotnet-sdk"
     directories:
-      - "/src/Seq.Input.MSSql.Tests"
-      - "/src/Seq.Input.MSSql"
+      - "src/Seq.Input.MSSql"
+      - "src/Seq.Input.MSSql.Tests"
     schedule:
       interval: "daily"

--- a/src/Seq.Input.MSSql/Executor.cs
+++ b/src/Seq.Input.MSSql/Executor.cs
@@ -99,9 +99,6 @@ namespace Seq.Input.MsSql
                                 .ForContext("QueryString", queryString).Debug(
                                     "Query new table rows from {StartDateTime} to {EndDateTime}", dateTime,
                                     runTime);
-                        else
-                            _logger.Debug("Query new table rows from {StartDateTime} to {EndDateTime}", dateTime,
-                                runTime);
 
                         // Create command and execute
                         command.CommandText = queryString;


### PR DESCRIPTION
Reduces noise in the Seq log stream when Debug is false.
Of course this has a side effect, that the background queries are invisible, but otherwise it's too chatty.